### PR TITLE
 Make ModID, ModVersion and OverwriteLegacy update instantly

### DIFF
--- a/SaveToGame/App.xaml.cs
+++ b/SaveToGame/App.xaml.cs
@@ -200,6 +200,10 @@ namespace SaveToGameWpf
 
             if (currentVersion < 0)
                 currentVersion = 0;
+            if (latestSettings.ModId.IsNullOrEmpty())
+                latestSettings.ModId = "CoolMod";
+            if (latestSettings.ModVersion < 1)
+                latestSettings.ModVersion = 1;
 
             while (currentVersion < GlobalVariables.LatestSettingsVersion)
             {

--- a/SaveToGame/App.xaml.cs
+++ b/SaveToGame/App.xaml.cs
@@ -200,10 +200,6 @@ namespace SaveToGameWpf
 
             if (currentVersion < 0)
                 currentVersion = 0;
-            if (latestSettings.ModId.IsNullOrEmpty())
-                latestSettings.ModId = "CoolMod";
-            if (latestSettings.ModVersion < 1)
-                latestSettings.ModVersion = 1;
 
             while (currentVersion < GlobalVariables.LatestSettingsVersion)
             {

--- a/SaveToGame/Logic/ViewModels/MainWindowViewModel.cs
+++ b/SaveToGame/Logic/ViewModels/MainWindowViewModel.cs
@@ -2,6 +2,7 @@
 using Interfaces.OrganisationItems;
 using Interfaces.ViewModels;
 using MVVM_Tools.Code.Providers;
+using SaveToGameWpf.Logic.Utils;
 using SaveToGameWpf.Resources.Localizations;
 using SharedData.Enums;
 
@@ -9,6 +10,11 @@ namespace SaveToGameWpf.Logic.ViewModels
 {
     public class MainWindowViewModel : IMainWindowViewModel
     {
+        // backing fields
+        private IProperty<string> _modId;
+        private IProperty<int> _modVersion;
+        private IProperty<bool> _overwriteLegacy;
+        
         public IProperty<bool> Working { get; }
         public IProperty<bool> OnlySave { get; }
         public IProperty<bool> SavePlusMess { get; }
@@ -17,9 +23,23 @@ namespace SaveToGameWpf.Logic.ViewModels
         public IProperty<string> PopupBoxText { get; }
         public IProperty<int> MessagesCount { get; }
 
-        public IProperty<string> ModID { get; }
-        public IProperty<int> ModVersion { get; }
-        public IProperty<bool> OverwriteLegacy { get; }
+        public IProperty<string> ModID
+        {
+            get => _modId;
+            set => _modId = value;
+        }
+
+        public IProperty<int> ModVersion
+        {
+            get => _modVersion;
+            set => _modVersion = value;
+        }
+
+        public IProperty<bool> OverwriteLegacy
+        {
+            get => _overwriteLegacy;
+            set => _overwriteLegacy = value;
+        }
 
 
         public IProperty<string> CurrentApk { get; }

--- a/SaveToGame/Windows/MainWindow.xaml
+++ b/SaveToGame/Windows/MainWindow.xaml
@@ -234,7 +234,7 @@
                     <TextBox
                         Grid.Column="1"
                         Text="{Binding ModVersion.Value}"
-                        AcceptsReturn="False" MaxLines="1" Margin="5,0,0,1" Height="25" VerticalAlignment="Bottom" PreviewTextInput="TextBox_PreviewTextInput"/>
+                        AcceptsReturn="False" MaxLines="1" Margin="5,0,0,1" Height="25" VerticalAlignment="Bottom" PreviewTextInput="VerifyVersionInput"/>
                 </Grid>
 
                 <GroupBox

--- a/SaveToGame/Windows/MainWindow.xaml.cs
+++ b/SaveToGame/Windows/MainWindow.xaml.cs
@@ -72,6 +72,16 @@ namespace SaveToGameWpf.Windows
             Provider<IApktool> apktoolProvider
         )
         {
+            if (appSettings.ModId.IsNullOrEmpty())
+            {
+                appSettings.ModId = "CoolMod";
+                viewModel.ModID.Value = "CoolMod";
+            }
+            if (appSettings.ModVersion < 1)
+            {
+                appSettings.ModVersion = 1;
+                viewModel.ModVersion.Value = 1;
+            }
             _settings = appSettings;
             _applicationUtils = applicationUtils;
             _mainWindowProvider = mainWindowProvider;

--- a/SaveToGame/Windows/MainWindow.xaml.cs
+++ b/SaveToGame/Windows/MainWindow.xaml.cs
@@ -394,21 +394,28 @@ namespace SaveToGameWpf.Windows
                             resultExternalDataPath: externalBackup,
                             tempFolderProvider: tempFolderProvider
                         );
-                        ApkModifer.ParseBackup(
-                            pathToBackup: pathToSetupSave,
-                            backupType: backupType,
-                            resultInternalDataPath: internalSetupBackup,
-                            resultExternalDataPath: externalSetupBackup,
-                            tempFolderProvider: tempFolderProvider
-                        );
-
+                        
                         var fileToAssetsName = new Dictionary<string, string>
                         {
                             {internalBackup, "data.save"},
                             {externalBackup, "extdata.save"},
-                            {internalSetupBackup, "setupdata.save"},
-                            {externalSetupBackup, "extsetupdata.save"}
                         };
+                        
+                        if (!pathToSetupSave.IsNullOrEmpty())
+                        {
+                            ApkModifer.ParseBackup(
+                                pathToBackup: pathToSetupSave,
+                                backupType: backupType,
+                                resultInternalDataPath: internalSetupBackup,
+                                resultExternalDataPath: externalSetupBackup,
+                                tempFolderProvider: tempFolderProvider
+                            );
+                            
+                            fileToAssetsName.Add(internalSetupBackup, "setupdata.save");
+                            fileToAssetsName.Add(externalSetupBackup, "extsetupdata.save");
+                        }
+
+                        
 
                         foreach (var (file, assetsName) in fileToAssetsName.Enumerate())
                         {

--- a/SaveToGame/Windows/MainWindow.xaml.cs
+++ b/SaveToGame/Windows/MainWindow.xaml.cs
@@ -8,7 +8,6 @@ using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Windows;
-using System.Windows.Controls;
 using System.Windows.Shell;
 using AndroidHelper.Logic;
 using AndroidHelper.Logic.Interfaces;

--- a/SaveToGame/Windows/MainWindow.xaml.cs
+++ b/SaveToGame/Windows/MainWindow.xaml.cs
@@ -183,6 +183,11 @@ namespace SaveToGameWpf.Windows
             string apkFile = ViewModel.CurrentApk.Value;
             string saveFile = ViewModel.CurrentSave.Value;
 
+            if (ViewModel.ModID.Value.IsNullOrEmpty())
+                ViewModel.ModID.Value = "CoolMod";
+            if (ViewModel.ModVersion.Value < 1)
+                ViewModel.ModVersion.Value = 1;
+            
             _settings.ModId = ViewModel.ModID.Value;
             _settings.ModVersion = ViewModel.ModVersion.Value;
             _settings.OverwriteLegacy = ViewModel.OverwriteLegacy.Value;

--- a/SaveToGame/Windows/MainWindow.xaml.cs
+++ b/SaveToGame/Windows/MainWindow.xaml.cs
@@ -8,6 +8,7 @@ using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Windows;
+using System.Windows.Controls;
 using System.Windows.Shell;
 using AndroidHelper.Logic;
 using AndroidHelper.Logic.Interfaces;
@@ -71,11 +72,6 @@ namespace SaveToGameWpf.Windows
             Provider<IApktool> apktoolProvider
         )
         {
-            //TODO we should use the c# property thingies for this.
-            if (appSettings.ModId.IsNullOrEmpty())
-                appSettings.ModId = "CoolMod";
-            if(appSettings.ModVersion < 1)
-                appSettings.ModVersion = 1;
             _settings = appSettings;
             _applicationUtils = applicationUtils;
             _mainWindowProvider = mainWindowProvider;
@@ -177,7 +173,11 @@ namespace SaveToGameWpf.Windows
             string apkFile = ViewModel.CurrentApk.Value;
             string saveFile = ViewModel.CurrentSave.Value;
 
-            #region Проверка на существование файлов
+            _settings.ModId = ViewModel.ModID.Value;
+            _settings.ModVersion = ViewModel.ModVersion.Value;
+            _settings.OverwriteLegacy = ViewModel.OverwriteLegacy.Value;
+            
+            #region Checking for file existence
 
             if (string.IsNullOrEmpty(apkFile) || !File.Exists(apkFile) ||
                 (ViewModel.SavePlusMess.Value || ViewModel.OnlySave.Value) &&
@@ -481,10 +481,10 @@ namespace SaveToGameWpf.Windows
                             addSave: backupFilesAdded,
                             message: needMessage ? popupText : string.Empty,
                             messagesCount: needMessage ? messagesCount : 0,
-                            modid: _settings.ModId,
+                            modid: ViewModel.ModID.Value,
                             overwriteExisting: false,
-                            overwriteLegacy: _settings.OverwriteLegacy,
-                            version: _settings.ModVersion
+                            overwriteLegacy: ViewModel.OverwriteLegacy.Value,
+                            version: ViewModel.ModVersion.Value
                         );
 
                         manifest.MainSmaliFile.AddTextToMethod(FileResources.MainSmaliCall);
@@ -660,12 +660,11 @@ namespace SaveToGameWpf.Windows
             }
         }
 
-        private void TextBox_PreviewTextInput(object sender, TextCompositionEventArgs e)
+        private void VerifyVersionInput(object sender, TextCompositionEventArgs e)
         {
-            // Check if the entered character is a digit
-            if (!Char.IsDigit(e.Text, 0))
+            if (!char.IsDigit(e.Text, 0)) // ignore non character input for modversion
             {
-                e.Handled = true; // Ignore the input if it's not a digit
+                e.Handled = true;
             }
         }
 


### PR DESCRIPTION
Previously, these 3 options would only update after the application closes. Now, they update instantly (whenever the inputs are changed). The physical appSettings.json file is updated when the user clicks "Start", and when the application closes (as usual).